### PR TITLE
Readd npm check with gte check

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "faucet": "0.0.1"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=0.10",
+    "npm": ">=1"
   },
   "scripts": {
     "test": "faucet"


### PR DESCRIPTION
this change re-adds the npm check but makes it check for a version greater than or equal to 1.